### PR TITLE
Add sitemap.xml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'middleman', '~> 4.1'
 gem 'middleman-blog'
 gem 'middleman-syntax'
 gem 'middleman-dotenv', '~> 2.0'
+gem 'middleman-search_engine_sitemap'
 
 # site search
 gem 'algoliasearch'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     middleman-dotenv (2.0.0)
       dotenv (>= 2.0)
       middleman-core (>= 4.0)
+    middleman-search_engine_sitemap (1.4.0)
+      builder
+      middleman-core (~> 4.0)
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
@@ -139,6 +142,7 @@ DEPENDENCIES
   middleman-blog
   middleman-blog-similar
   middleman-dotenv (~> 2.0)
+  middleman-search_engine_sitemap
   middleman-syntax
   redcarpet (~> 3.3, >= 3.3.3)
   tzinfo-data

--- a/config.rb
+++ b/config.rb
@@ -81,6 +81,9 @@ end
 activate :syntax, :line_numbers => false
 activate :similar
 
+set :url_root, config[:meta][:siteurl]
+activate :search_engine_sitemap
+
 activate :external_pipeline, {
   name: :webpack,
   command: build? ?


### PR DESCRIPTION
Fixed #9

see https://github.com/Aupajo/middleman-search_engine_sitemap

- [x] Can access /sitemap.xml on `middleman serve`
- [x] Include build/sitemap.xml on `middleman build`
