### PR TITLE
iOSで画像の遅延ロードが効かない問題を解消した

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-polyfill": "^6.23.0",
     "bluebird": "^3.5.0",
     "classnames": "^2.2.5",
+    "intersection-observer": "^0.4.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/source/javascripts/LazyLoadApp/index.js
+++ b/source/javascripts/LazyLoadApp/index.js
@@ -1,3 +1,5 @@
+// importだと静的に解決されてpolifillにならないのでrequire
+import 'intersection-observer'
 
 export default function lazyLoader (images: NodeList<HTMLElement>): void {
   const callback = function(entries, observer) { 

--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Dispatcher, Context } from 'almin'
+import AlminLogger from 'almin-logger'
 import AppStoreGroup from './store/AppStoreGroup'
 import SearchApp from './SearchApp'
 import LazyLoadApp from './LazyLoadApp'
@@ -16,7 +17,6 @@ const appContext = new Context({
 })
 
 if (process.env.NODE_ENV !== 'production') {
-  const { AlminLogger } = require('almin-logger')
   const logger = new AlminLogger()
   logger.startLogging(appContext)
 }


### PR DESCRIPTION
Fixed #129 