### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - node_modules
     - build
     - .imageoptim_cache
+    - .textlintcache
 
 before_install:
 - git config user.name 'WEB-EGG bot'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - node_modules
     - build
+    - .imageoptim_cache
 
 before_install:
 - git config user.name 'WEB-EGG bot'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
 cache:
   bundler: true
   directories:
-    - /home/travis/.rvm/
+    - /home/travis/.rvm
+    - /home/travis/.flow-typed
     - node_modules
     - build
     - .caches

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 cache:
   bundler: true
   directories:
+    - /home/travis/.rvm/
     - node_modules
     - build
     - .imageoptim_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache:
     - /home/travis/.rvm/
     - node_modules
     - build
-    - .imageoptim_cache
-    - .textlintcache
+    - .caches
 
 before_install:
 - git config user.name 'WEB-EGG bot'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - 6.1.0
+cache:
+  bundler: true
+  directories:
+    - node_modules
+    - build
 
 before_install:
 - git config user.name 'WEB-EGG bot'

--- a/config.rb
+++ b/config.rb
@@ -283,7 +283,7 @@ configure :build do
         :skip_missing_workers => true, # Skip workers with missing or problematic binaries _(defaults to `false`)_
         :verbose => true,              # Verbose output _(defaults to `false`)_
         :allow_lossy => true,          # Allow lossy workers and optimizations _(defaults to `false`)_
-        :cache_dir => '.imageoptim_cache'
+        :cache_dir => '.imageoptim_cache',
 
         # PNG では OptiPNG または PNGOUT をおすすめします。
         # https://developers.google.com/speed/docs/insights/OptimizeImages

--- a/config.rb
+++ b/config.rb
@@ -283,6 +283,7 @@ configure :build do
         :skip_missing_workers => true, # Skip workers with missing or problematic binaries _(defaults to `false`)_
         :verbose => true,              # Verbose output _(defaults to `false`)_
         :allow_lossy => true,          # Allow lossy workers and optimizations _(defaults to `false`)_
+        :cache_dir => '.imageoptim_cache'
 
         # PNG では OptiPNG または PNGOUT をおすすめします。
         # https://developers.google.com/speed/docs/insights/OptimizeImages

--- a/config.rb
+++ b/config.rb
@@ -283,7 +283,7 @@ configure :build do
         :skip_missing_workers => true, # Skip workers with missing or problematic binaries _(defaults to `false`)_
         :verbose => true,              # Verbose output _(defaults to `false`)_
         :allow_lossy => true,          # Allow lossy workers and optimizations _(defaults to `false`)_
-        :cache_dir => '.imageoptim_cache',
+        :cache_dir => '.caches/.imageoptim_cache',
 
         # PNG では OptiPNG または PNGOUT をおすすめします。
         # https://developers.google.com/speed/docs/insights/OptimizeImages

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "flow-typed install",
     "test": "{TODO}",
     "lint:flow": "flow",
-    "lint:md": "textlint -f pretty-error source/post/*.md",
+    "lint:md": "textlint --cache -f pretty-error source/post/*.md",
     "lint:md:fix": "textlint --fix source/post/*.md",
     "develop": "webpack --config ./webpack.config.js --watch -d --progress --colors",
     "build": "webpack --config ./webpack.config.js --bail -p",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "flow-typed install",
     "test": "{TODO}",
     "lint:flow": "flow",
-    "lint:md": "textlint --cache -f pretty-error source/post/*.md",
+    "lint:md": "textlint --cache --cache-location .caches/.textlintcache -f pretty-error source/post/*.md",
     "lint:md:fix": "textlint --fix source/post/*.md",
     "develop": "webpack --config ./webpack.config.js --watch -d --progress --colors",
     "build": "webpack --config ./webpack.config.js --bail -p",


### PR DESCRIPTION
Enable cache to reduce build time

- Cache textlint
- Cache flow-typed
- Cache rvm (Ruby version manager)
- Cache bundler gems
- Cache npm packages (node_modules)
- **Cache image_optim** (it takes 20-25m every build)

Build time faster than **15-25**m before!! (before: 30m-40m)
